### PR TITLE
Add Dependabot, use Dependency Submission API

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+
+updates:
+  - package-ecosystem: gradle
+    directory: /
+    schedule:
+      interval: weekly
+    target-branch: main
+
+  - package-ecosystem: cargo
+    directory: divviup/rust
+    schedule:
+      interval: weekly
+    ignore:
+      - dependency-name: prio
+        update-types:
+          - version-update:semver-minor
+      - dependency-name: janus_*
+        update-types:
+          - version-update:semver-minor
+    groups:
+      janus:
+        patterns:
+          - janus_*
+    target-branch: main
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    target-branch: main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 jobs:
-  check:
+  build:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -21,6 +21,8 @@ jobs:
         check-latest: false
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
+      with:
+        dependency-graph: generate-and-submit
     - name: Setup Rust
       id: rust-toolchain
       uses: dtolnay/rust-toolchain@stable
@@ -35,3 +37,10 @@ jobs:
       run: ./gradlew build
       # Note that `connectedCheck` is skipped for now, because setting up an
       # emulator is nontrivial.
+
+  dependency-review:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Dependency review
+      uses: actions/dependency-review-action@v3


### PR DESCRIPTION
See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates#gradle, Dependabot needs us to use the "dependency submission API" in order to send security alerts about transitive dependencies. Fortunately, gradle/gradle-build-action supports this.