### PR TITLE
Include version in User-Agent via BuildConfig

### DIFF
--- a/divviup/build.gradle.kts
+++ b/divviup/build.gradle.kts
@@ -9,11 +9,19 @@ android {
 
     ndkVersion = "26.1.10909125"
 
+    buildFeatures {
+        buildConfig = true
+    }
+
     defaultConfig {
         minSdk = 21
 
+        version = "0.1.0-SNAPSHOT"
+
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
+
+        buildConfigField("String", "VERSION", "\"" + version.toString() + "\"")
     }
 
     buildTypes {

--- a/divviup/src/main/java/org/divviup/android/Client.java
+++ b/divviup/src/main/java/org/divviup/android/Client.java
@@ -166,12 +166,7 @@ public class Client<M> {
     }
 
     private static String getUserAgent() {
-        Package pkg = Client.class.getPackage();
-        if (pkg != null) {
-            return "divviup-android/" + pkg.getImplementationVersion();
-        } else {
-            return "divviup-android";
-        }
+        return "divviup-android/" + BuildConfig.VERSION;
     }
 
     private long reportTimestamp() {


### PR DESCRIPTION
The `getImplementationVersion()` method for getting our library's version does not work, because no version number is preserved when packaging a library into an AAR. This PR instead generates a Java source file, and passes the version number from the build system into the final library through that.