### PR TITLE
Add Google's Maven repository to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,10 @@
 version: 2
 
+registries:
+  google:
+    type: maven-repository:
+    url: https://dl.google.com/dl/android/maven2/
+
 updates:
   - package-ecosystem: gradle
     directory: /


### PR DESCRIPTION
This should open upgrade PRs for AGP 8.1.3 once landed.