### PR TITLE
Add google registry under "updates" as well

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ registries:
 updates:
   - package-ecosystem: gradle
     directory: /
+    registries:
+      - google
     schedule:
       interval: weekly
     target-branch: main


### PR DESCRIPTION
We additionally need to reference the registry previously defined at top level in the update job itself.