### PR TITLE
Add Dependabot groups for Gradle dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,17 @@ updates:
       - google
     schedule:
       interval: weekly
+    groups:
+      agp:
+        patterns:
+          - com.android.application
+          - com.android.library
+      logback:
+        patterns:
+          - ch.qos.logback:*
+      jetpack:
+        patterns:
+          - androidx.*
     target-branch: main
 
   - package-ecosystem: cargo


### PR DESCRIPTION
This sets up some Dependabot groups for Android/Java dependencies.