### PR TITLE
Add Gradle tasks to generate Javadoc

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,9 +46,7 @@ jobs:
       working-directory: divviup/rust
       run: cargo clippy
     - name: Build and test
-      run: ./gradlew build
-      # Note that `connectedCheck` is skipped for now, because setting up an
-      # emulator is nontrivial.
+      run: ./gradlew build generateReleaseJavadoc
 
   dependency-review:
     if: github.event_name == 'pull_request'

--- a/divviup/build.gradle.kts
+++ b/divviup/build.gradle.kts
@@ -72,3 +72,14 @@ tasks.withType<Test>().matching { it.name.matches(Regex("test.*UnitTest"))}.conf
     val capitalizedHostRustTarget = hostRustTarget.replaceFirstChar { it.uppercase() }
     dependsOn(tasks.named("cargoBuild${capitalizedHostRustTarget}"))
 }
+
+afterEvaluate {
+    android.libraryVariants.forEach { variant ->
+        val capitalizedVariantName = variant.name.replaceFirstChar { it.uppercase() }
+        tasks.register<Javadoc>("generate${capitalizedVariantName}Javadoc") {
+            source = android.sourceSets["main"].java.getSourceFiles()
+            classpath += files(android.bootClasspath)
+            classpath += files(variant.compileConfiguration)
+        }
+    }
+}


### PR DESCRIPTION
This adds a Gradle task to run `javadoc`. The trickiest part was figuring out how to get JARs of dependencies on the classpath without hacks with hardcoded paths or unneeded `TaskProvider.get()` calls.

Part of #9.