### PR TITLE
Configure publishing tasks

### DIFF
--- a/divviup/build.gradle.kts
+++ b/divviup/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.android.library")
     id("org.mozilla.rust-android-gradle.rust-android")
+    id("maven-publish")
 }
 
 android {
@@ -33,6 +34,13 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
+    publishing {
+        singleVariant("release") {
+            withSourcesJar()
+            withJavadocJar()
+        }
     }
 }
 
@@ -80,6 +88,19 @@ afterEvaluate {
             source = android.sourceSets["main"].java.getSourceFiles()
             classpath += files(android.bootClasspath)
             classpath += files(variant.compileConfiguration)
+        }
+    }
+}
+
+publishing {
+    publications {
+        register<MavenPublication>("release") {
+            groupId = "org.divviup.android"
+            artifactId = "divviup-android"
+
+            afterEvaluate {
+                from(components["release"])
+            }
         }
     }
 }


### PR DESCRIPTION
This adds a publishing task, using the Maven Publish Plugin, and the Android Gradle Plugin's integration. I ran `./gradlew publishReleasePublicationToMavenLocal` and it successfully published to `~/.m2/repository/org/divviup/android/divviup-android/0.1.0-SNAPSHOT/`.

I noticed that adding this introduced new javaDocReleaseGeneration and javaDocReleaseJar Gradle tasks, separate from those I added in #39. This is writing out to `divviup/build/intermediates/java_doc_dir/release/`, as opposed to `divviup/build/docs/javadoc/`. The new task is of type `com.android.build.gradle.tasks.JavaDocGenerationTask_Decorated` instead of `org.gradle.api.tasks.javadoc.Javadoc_Decorated`. I think I'll let them coexist for the time being.

Part of #14.