### PR TITLE
Switch to OkHttp for its caching support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ public class MyRunnable implements Runnable {
             URI helperEndpoint = new URI("https://<your helper here>/");
             TaskId taskId = TaskId.parse("<your DAP TaskId here>");
             long timePrecisionSeconds = <your time precision here>;
-            Client<Boolean> client = Client.createPrio3Count(leaderEndpoint, helperEndpoint, taskId, timePrecisionSeconds);
+            Client<Boolean> client = Client.createPrio3Count(context, leaderEndpoint, helperEndpoint, taskId, timePrecisionSeconds);
             client.sendMeasurement(<your measurement here>);
         } catch (Exception e) {
             Log.e("MyRunnable", "upload failed", e);

--- a/divviup/build.gradle.kts
+++ b/divviup/build.gradle.kts
@@ -45,7 +45,7 @@ android {
 }
 
 dependencies {
-    implementation("commons-io:commons-io:2.15.0")
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
     testImplementation(project(":divviup:commontest"))
     testImplementation("junit:junit:4.13.2")
     testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
@@ -53,6 +53,8 @@ dependencies {
     testImplementation("com.fasterxml.jackson.core:jackson-databind:2.16.0")
     testImplementation("ch.qos.logback:logback-core:1.4.12")
     testImplementation("ch.qos.logback:logback-classic:1.4.12")
+    testImplementation("commons-io:commons-io:2.15.0")
+    testImplementation("org.mockito:mockito-core:5.7.0")
     androidTestImplementation(project(":divviup:commontest"))
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")

--- a/divviup/src/androidTest/java/org/divviup/android/InstrumentedSmokeTest.java
+++ b/divviup/src/androidTest/java/org/divviup/android/InstrumentedSmokeTest.java
@@ -1,12 +1,15 @@
 package org.divviup.android;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
 
 import org.divviup.commontest.MockAggregator;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assert.*;
+
+import android.content.Context;
 
 import java.io.IOException;
 import java.net.URI;
@@ -20,9 +23,10 @@ public class InstrumentedSmokeTest {
 
     @Test
     public void smokeTestPrio3Count() throws IOException, InterruptedException {
+        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
         try (MockWebServer server = MockAggregator.setupMockServer()) {
             URI uri = server.url("/").uri();
-            Client<Boolean> client = Client.createPrio3Count(uri, uri, ZERO_TASK_ID, 300);
+            Client<Boolean> client = Client.createPrio3Count(context, uri, uri, ZERO_TASK_ID, 300);
             client.sendMeasurement(true);
 
             basicUploadChecks(server);
@@ -31,9 +35,10 @@ public class InstrumentedSmokeTest {
 
     @Test
     public void smokeTestPrio3Sum() throws IOException, InterruptedException {
+        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
         try (MockWebServer server = MockAggregator.setupMockServer()) {
             URI uri = server.url("/").uri();
-            Client<Long> client = Client.createPrio3Sum(uri, uri, ZERO_TASK_ID, 300, 32);
+            Client<Long> client = Client.createPrio3Sum(context, uri, uri, ZERO_TASK_ID, 300, 32);
             client.sendMeasurement(1000000L);
 
             basicUploadChecks(server);
@@ -42,9 +47,10 @@ public class InstrumentedSmokeTest {
 
     @Test
     public void smokeTestPrio3SumVec() throws IOException, InterruptedException {
+        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
         try (MockWebServer server = MockAggregator.setupMockServer()) {
             URI uri = server.url("/").uri();
-            Client<long[]> client = Client.createPrio3SumVec(uri, uri, ZERO_TASK_ID, 300, 10, 8, 12);
+            Client<long[]> client = Client.createPrio3SumVec(context, uri, uri, ZERO_TASK_ID, 300, 10, 8, 12);
             client.sendMeasurement(new long[] {252L, 7L, 80L, 194L, 190L, 217L, 141L, 85L, 222L, 243L});
 
             basicUploadChecks(server);
@@ -53,9 +59,10 @@ public class InstrumentedSmokeTest {
 
     @Test
     public void smokeTestPrio3Histogram() throws IOException, InterruptedException {
+        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
         try (MockWebServer server = MockAggregator.setupMockServer()) {
             URI uri = server.url("/").uri();
-            Client<Long> client = Client.createPrio3Histogram(uri, uri, ZERO_TASK_ID, 300, 5, 2);
+            Client<Long> client = Client.createPrio3Histogram(context, uri, uri, ZERO_TASK_ID, 300, 5, 2);
             client.sendMeasurement(2L);
 
             basicUploadChecks(server);

--- a/divviup/src/test/java/org/divviup/android/HostSmokeTest.java
+++ b/divviup/src/test/java/org/divviup/android/HostSmokeTest.java
@@ -1,9 +1,18 @@
 package org.divviup.android;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+
+import android.content.Context;
 
 import org.divviup.commontest.MockAggregator;
+import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.IOException;
 import java.net.URI;
@@ -11,14 +20,26 @@ import java.net.URI;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
 
+@RunWith(MockitoJUnitRunner.class)
 public class HostSmokeTest {
     private static final TaskId ZERO_TASK_ID = TaskId.parse("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+
+    @ClassRule
+    public static final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Mock(strictness = Mock.Strictness.LENIENT)
+    private static Context mockContext;
+
+    @Before
+    public void initMock() {
+        when(mockContext.getCacheDir()).thenReturn(temporaryFolder.getRoot());
+    }
 
     @Test
     public void smokeTestPrio3Count() throws IOException, InterruptedException {
         try (MockWebServer server = MockAggregator.setupMockServer()) {
             URI uri = server.url("/").uri();
-            Client<Boolean> client = Client.createPrio3Count(uri, uri, ZERO_TASK_ID, 300);
+            Client<Boolean> client = Client.createPrio3Count(mockContext, uri, uri, ZERO_TASK_ID, 300);
             client.sendMeasurement(true);
 
             basicUploadChecks(server);
@@ -29,7 +50,7 @@ public class HostSmokeTest {
     public void smokeTestPrio3Sum() throws IOException, InterruptedException {
         try (MockWebServer server = MockAggregator.setupMockServer()) {
             URI uri = server.url("/").uri();
-            Client<Long> client = Client.createPrio3Sum(uri, uri, ZERO_TASK_ID, 300, 32);
+            Client<Long> client = Client.createPrio3Sum(mockContext, uri, uri, ZERO_TASK_ID, 300, 32);
             client.sendMeasurement(1000000L);
 
             basicUploadChecks(server);
@@ -40,7 +61,7 @@ public class HostSmokeTest {
     public void smokeTestPrio3SumVec() throws IOException, InterruptedException {
         try (MockWebServer server = MockAggregator.setupMockServer()) {
             URI uri = server.url("/").uri();
-            Client<long[]> client = Client.createPrio3SumVec(uri, uri, ZERO_TASK_ID, 300, 10, 8, 12);
+            Client<long[]> client = Client.createPrio3SumVec(mockContext, uri, uri, ZERO_TASK_ID, 300, 10, 8, 12);
             client.sendMeasurement(new long[] {252L, 7L, 80L, 194L, 190L, 217L, 141L, 85L, 222L, 243L});
 
             basicUploadChecks(server);
@@ -51,7 +72,7 @@ public class HostSmokeTest {
     public void smokeTestPrio3Histogram() throws IOException, InterruptedException {
         try (MockWebServer server = MockAggregator.setupMockServer()) {
             URI uri = server.url("/").uri();
-            Client<Long> client = Client.createPrio3Histogram(uri, uri, ZERO_TASK_ID, 300, 5, 2);
+            Client<Long> client = Client.createPrio3Histogram(mockContext, uri, uri, ZERO_TASK_ID, 300, 5, 2);
             client.sendMeasurement(2L);
 
             basicUploadChecks(server);

--- a/sampleapp/src/main/java/org/divviup/sampleapp/MainActivity.java
+++ b/sampleapp/src/main/java/org/divviup/sampleapp/MainActivity.java
@@ -1,5 +1,6 @@
 package org.divviup.sampleapp;
 
+import android.content.Context;
 import android.os.Bundle;
 
 import com.google.android.material.snackbar.Snackbar;
@@ -112,7 +113,7 @@ public class MainActivity extends AppCompatActivity {
             boolean measurement = index == R.id.trueRadioButton;
 
             executorService.submit(
-                    new ReportSubmissionJob(view, leaderUri, helperUri, taskId, timePrecision, measurement)
+                    new ReportSubmissionJob(this, view, leaderUri, helperUri, taskId, timePrecision, measurement)
             );
         });
     }
@@ -126,6 +127,7 @@ public class MainActivity extends AppCompatActivity {
     private static class ReportSubmissionJob implements Runnable {
         private static final String TAG = "ReportSubmissionJob";
 
+        private final Context context;
         private final View view;
         private final URI leaderEndpoint, helperEndpoint;
         private final TaskId taskId;
@@ -133,6 +135,7 @@ public class MainActivity extends AppCompatActivity {
         private final boolean measurement;
 
         public ReportSubmissionJob(
+                Context context,
                 View view,
                 URI leaderEndpoint,
                 URI helperEndpoint,
@@ -140,6 +143,7 @@ public class MainActivity extends AppCompatActivity {
                 long timePrecisionSeconds,
                 boolean measurement
         ) {
+            this.context = context;
             this.view = view;
             this.leaderEndpoint = leaderEndpoint;
             this.helperEndpoint = helperEndpoint;
@@ -151,7 +155,7 @@ public class MainActivity extends AppCompatActivity {
         public void run() {
             Handler handler = new Handler(Looper.getMainLooper());
 
-            Client<Boolean> client = Client.createPrio3Count(leaderEndpoint, helperEndpoint, taskId, timePrecisionSeconds);
+            Client<Boolean> client = Client.createPrio3Count(context, leaderEndpoint, helperEndpoint, taskId, timePrecisionSeconds);
             try {
                 client.sendMeasurement(measurement);
                 handler.post(


### PR DESCRIPTION
This switches from HttpUrlConnection to OkHttp, so we can make use of their caching feature, while still maintaining broad API level compatibility. In order to support this, we have to thread a `Context` argument through our factory methods. Closes #6.