### PR TITLE
Specify NDK version in :sampleapp

### DIFF
--- a/sampleapp/build.gradle.kts
+++ b/sampleapp/build.gradle.kts
@@ -6,6 +6,8 @@ android {
     namespace = "org.divviup.sampleapp"
     compileSdk = 34
 
+    ndkVersion = "26.1.10909125"
+
     defaultConfig {
         applicationId = "org.divviup.sampleapp"
         minSdk = 21


### PR DESCRIPTION
I've noticed this message a couple times in the output.

> Unable to strip the following libraries, packaging them as they are: libdivviup_android.so.

It turns out that the `sampleapp` project was missing a declaration of the NDK version to use, like we currently have in the `divviup` project. This led to AGP falling back to its default NDK version, but that version is not installed on GitHub Actions worker VMs anymore. Specifying this version will clean up this warning from the logs.