### PR TITLE
Demonstration of dependency on snapshot

### DIFF
--- a/sampleapp/build.gradle.kts
+++ b/sampleapp/build.gradle.kts
@@ -34,7 +34,7 @@ android {
 }
 
 dependencies {
-    implementation(project(":divviup"))
+    implementation("org.divviup.android:divviup-android:0.1.0-SNAPSHOT")
 
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("com.google.android.material:material:1.10.0")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,6 +10,12 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        repositories {
+            maven {
+                name = "OSSRH Snapshots"
+                url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This commit demonstrates that we can build against a published AAR snapshot, downloaded from the appropriate repository. I built the sample app with this locally and ran it in my emulator.