### PR TITLE
Prepare to release version 0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,32 @@ and releases.
 
 | Package version     | Git branch | Protocol version                    | Conformant? | Status    |
 |---------------------|------------|-------------------------------------|-------------|-----------|
-| 0.1.0 (forthcoming) | `main`     | [`draft-ietf-ppm-dap-07`][draft-07] | Yes         | Supported |
+| 0.1.0 | `main`     | [`draft-ietf-ppm-dap-07`][draft-07] | Yes         | Supported |
 
 [draft-07]: https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/07/
 
 ## Usage
 
-Note that no published releases are available yet, so you must build this
-library from source for now. Add the AAR file to your project. Construct a
-`Client` from your DAP task's parameters, and use it to send report as follows.
+Ensure that Maven Central is in the list of repositories from which
+dependencies are resolved. Add the library to your project as follows.
+
+```groovy
+// build.gradle
+
+dependencies {
+    implementation 'org.divviup.android:divviup-android:0.1.0'
+}
+```
+
+```kotlin
+// build.gradle.kts
+
+dependencies {
+    implementation("org.divviup.android:divviup-android:0.1.0")
+}
+```
+
+Construct a `Client` from your DAP task's parameters, and use it to send report as follows.
 (Note that this should be done off the main thread)
 
 ```java

--- a/divviup/build.gradle.kts
+++ b/divviup/build.gradle.kts
@@ -18,7 +18,7 @@ android {
     defaultConfig {
         minSdk = 21
 
-        version = "0.1.0-SNAPSHOT"
+        version = "0.1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")


### PR DESCRIPTION
This updates the version number in preparation for cutting the initial release, and updates the README. Part of #14.

Next up, after merging this:

- Run the publish action, ~~either via workflow_dispatch or~~ by tagging a release
- "Close" the release via the Nexus Release Manager web UI
- Take the URL of the staging repository, and use it to test the artifacts, akin to #53
- If it looks good, click "Release" in Nexus, otherwise click "Drop" and repeat
- ~~Create a GitHub release if not yet already done in the first step~~
- Update the version in `divviup/build.gradle.kts` to be "0.1.1-SNAPSHOT" in preparation for development of the next version

Edit: I should tag a release in the first step. Otherwise, running publish manually at first, then tagging a release later, would result in an annoying actions failure because non-snapshot versions are immutable in Maven repositories.