### PR TITLE
Set targetSdk for tests

### DIFF
--- a/divviup/build.gradle.kts
+++ b/divviup/build.gradle.kts
@@ -26,6 +26,10 @@ android {
         buildConfigField("String", "VERSION", "\"" + version.toString() + "\"")
     }
 
+    testOptions {
+        targetSdk = 23
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = false


### PR DESCRIPTION
Instrumented tests (i.e. invoked by `./gradlew connectedCheck`) would fail on Android 14 emulators:
```
Exception thrown during onBeforeAll invocation of plugin com.android.tools.utp.plugins.host.apkinstaller.AndroidTestApkInstallerPlugin.
Failed to install APK(s): /Users/inahga-work/Projects/divviup-android/divviup/build/outputs/apk/androidTest/debug/divviup-debug-androidTest.apk
INSTALL_FAILED_DEPRECATED_SDK_VERSION: App package must target at least SDK version 23, but found 21
com.android.ddmlib.InstallException: INSTALL_FAILED_DEPRECATED_SDK_VERSION: App package must target at least SDK version 23, but found 21
        at com.android.ddmlib.internal.DeviceImpl.installRemotePackage(DeviceImpl.java:1409)
        at com.android.ddmlib.internal.DeviceImpl.installPackage(DeviceImpl.java:1235)
...
```
Evidently, the minimum allowable API version for Android 14 has been raised.

Raise the API version we use in tests to 23, while still leaving the minimum supported SDK at 21.

Note: `android.defaultConfig.targetSdk` has been [deprecated for libraries](https://developer.android.com/reference/tools/gradle-api/8.2/com/android/build/api/dsl/LibraryBaseFlavor#targetSdk()), replaced with `android.testConfig.targetSdk`. In the absense of either of these options, the DSL will default to using the `minSdk` version.