### PR TITLE
Switch to gradle/actions/setup-gradle

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
         java-version: "17"
         check-latest: false
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@v3.0.0
+      uses: gradle/actions/setup-gradle@v3.0.0
       with:
         dependency-graph: generate-and-submit
     - name: Setup Rust

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,7 +21,7 @@ jobs:
         java-version: "17"
         check-latest: false
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@v3.0.0
+      uses: gradle/actions/setup-gradle@v3.0.0
     - name: Setup Rust
       id: rust-toolchain
       uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
This switches to the new name for this action, see the [release notes](https://github.com/gradle/gradle-build-action/releases/tag/v3.0.0).