### PR TITLE
Update NDK to 26.2.11394342

### DIFF
--- a/divviup/build.gradle.kts
+++ b/divviup/build.gradle.kts
@@ -9,7 +9,7 @@ android {
     namespace = "org.divviup.android"
     compileSdk = 34
 
-    ndkVersion = "26.1.10909125"
+    ndkVersion = "26.2.11394342"
 
     buildFeatures {
         buildConfig = true

--- a/sampleapp/build.gradle.kts
+++ b/sampleapp/build.gradle.kts
@@ -6,7 +6,7 @@ android {
     namespace = "org.divviup.sampleapp"
     compileSdk = 34
 
-    ndkVersion = "26.1.10909125"
+    ndkVersion = "26.2.11394342"
 
     defaultConfig {
         applicationId = "org.divviup.sampleapp"


### PR DESCRIPTION
Fixes the failing builds--the GitHub Actions runner no longer has `26.1.10909125`. See https://github.com/actions/runner-images/issues/9387.

AIUI this is just a patch release https://github.com/android/ndk/releases/tag/r26c.