### PR TITLE
Fallback to install NDK in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,9 @@ jobs:
         java-version: "17"
         check-latest: false
     - name: Install NDK
-      run: sudo bash -c "echo y | ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager --install 'ndk;26.3.11579264'"
+      run: |
+        NDK_VERSION=$(awk -F= '/ndkVersion/ { print $2 }' gradle.properties)
+        sudo bash -c "echo y | ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager --install 'ndk;${NDK_VERSION}'"
     - name: Validate Gradle Wrapper
       uses: gradle/actions/wrapper-validation@v3
     - name: Setup Gradle

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,8 @@ jobs:
         distribution: temurin
         java-version: "17"
         check-latest: false
+    - name: Install NDK
+      run: sudo bash -c "echo y | ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager --install 'ndk;26.3.11579264'"
     - name: Validate Gradle Wrapper
       uses: gradle/actions/wrapper-validation@v3
     - name: Setup Gradle

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,7 +21,9 @@ jobs:
         java-version: "17"
         check-latest: false
     - name: Install NDK
-      run: sudo bash -c "echo y | ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager --install 'ndk;26.3.11579264'"
+      run: |
+        NDK_VERSION=$(awk -F= '/ndkVersion/ { print $2 }' gradle.properties)
+        sudo bash -c "echo y | ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager --install 'ndk;${NDK_VERSION}'"
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v3.3.0
     - name: Setup Rust

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,6 +20,8 @@ jobs:
         distribution: temurin
         java-version: "17"
         check-latest: false
+    - name: Install NDK
+      run: sudo bash -c "echo y | ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager --install 'ndk;26.3.11579264'"
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v3.3.0
     - name: Setup Rust

--- a/divviup/build.gradle.kts
+++ b/divviup/build.gradle.kts
@@ -9,7 +9,7 @@ android {
     namespace = "org.divviup.android"
     compileSdk = 34
 
-    ndkVersion = "26.3.11579264"
+    ndkVersion = findProperty("ndkVersion") as String
 
     buildFeatures {
         buildConfig = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,6 @@ android.useAndroidX=true
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+
+# Project property to globally set NDK version
+systemProp.org.gradle.project.ndkVersion=26.3.11579264

--- a/sampleapp/build.gradle.kts
+++ b/sampleapp/build.gradle.kts
@@ -6,7 +6,7 @@ android {
     namespace = "org.divviup.sampleapp"
     compileSdk = 34
 
-    ndkVersion = "26.3.11579264"
+    ndkVersion = findProperty("ndkVersion") as String
 
     defaultConfig {
         applicationId = "org.divviup.sampleapp"


### PR DESCRIPTION
I've been seeing a lot of "NDK is not installed" errors, so trying to track the preinstalled NDK version is seeming futile. This PR installs the desired NDK version on demand. I expect this should add a minute or so to CI runtime if it needs to be installed, and hopefully do nothing if we land on a runner that already has the right version installed. We can still bump the NDK version to try to keep up with the preinstalled version as an optimization, but this should give us a safety net when that goes wrong.