### PR TITLE
Fallback to install NDK in CI, 0.1 backport

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,10 @@ jobs:
         distribution: temurin
         java-version: "17"
         check-latest: false
+    - name: Install NDK
+      run: |
+        NDK_VERSION=$(awk -F= '/ndkVersion/ { print $2 }' gradle.properties)
+        sudo bash -c "echo y | ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager --install 'ndk;${NDK_VERSION}'"
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v3.3.0
       with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,6 +20,10 @@ jobs:
         distribution: temurin
         java-version: "17"
         check-latest: false
+    - name: Install NDK
+      run: |
+        NDK_VERSION=$(awk -F= '/ndkVersion/ { print $2 }' gradle.properties)
+        sudo bash -c "echo y | ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager --install 'ndk;${NDK_VERSION}'"
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v3.3.0
     - name: Setup Rust

--- a/divviup/build.gradle.kts
+++ b/divviup/build.gradle.kts
@@ -9,7 +9,7 @@ android {
     namespace = "org.divviup.android"
     compileSdk = 34
 
-    ndkVersion = "26.2.11394342"
+    ndkVersion = findProperty("ndkVersion") as String
 
     buildFeatures {
         buildConfig = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,6 @@ android.useAndroidX=true
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+
+# Project property to globally set NDK version
+systemProp.org.gradle.project.ndkVersion=26.3.11579264

--- a/sampleapp/build.gradle.kts
+++ b/sampleapp/build.gradle.kts
@@ -6,7 +6,7 @@ android {
     namespace = "org.divviup.sampleapp"
     compileSdk = 34
 
-    ndkVersion = "26.2.11394342"
+    ndkVersion = findProperty("ndkVersion") as String
 
     defaultConfig {
         applicationId = "org.divviup.sampleapp"


### PR DESCRIPTION
This backports #163. I also just realized that the release/0.1 and main branches had different NDK versions set before this PR, which explains the CI issues.