### PR TITLE
Publish to OSSRH via user token, not JIRA password

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -38,8 +38,8 @@ jobs:
         workspaces: divviup/rust
     - name: Upload artifacts
       env:
-        ORG_GRADLE_PROJECT_ossrhUsername: ${{ vars.OSSRH_USERNAME }}
-        ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.OSSRH_PASSWORD }}
+        ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.OSSRH_USER_TOKEN_USERNAME }}
+        ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.OSSRH_USER_TOKEN_PASSWORD }}
         ORG_GRADLE_PROJECT_signingKey: ${{ secrets.PGP_SIGNING_KEY }}
         ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.PGP_SIGNING_PASSPHRASE }}
       run: ./gradlew :divviup:publishReleasePublicationToOSSRHRepository


### PR DESCRIPTION
This swaps out publishing to use a different username and password, which form a "user token". These are stored in two new GitHub Actions secrets. See https://central.sonatype.org/publish/generate-token/ for documentation.