### PR TITLE
Replace crate_type with crate-type

### DIFF
--- a/divviup/rust/Cargo.toml
+++ b/divviup/rust/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [lib]
-crate_type = ["cdylib"]
+crate-type = ["cdylib"]
 
 [dependencies]
 janus_core = "0.7.21"


### PR DESCRIPTION
This fixes a warning, and gets us ready for the 2024 edition of Rust. See https://doc.rust-lang.org/nightly/edition-guide/rust-2024/cargo-table-key-names.html