### PR TITLE
CI debugging

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,9 +51,10 @@ jobs:
     - name: Rust lint
       working-directory: divviup/rust
       run: cargo clippy
-    - run: id
+    - run: sudo chown -R runner:docker "$HOME/.config/.android"
     - run: ls -al "$HOME/.config"
     - run: ls -al "$HOME/.config/.android"
+    - run: ls -al "$HOME/.config/.android/cache"
     - name: Build and test
       run: ./gradlew build generateReleaseJavadoc
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,6 +51,9 @@ jobs:
     - name: Rust lint
       working-directory: divviup/rust
       run: cargo clippy
+    - run: id
+    - run: ls -al "$HOME/.config"
+    - run: ls -al "$HOME/.config/.android"
     - name: Build and test
       run: ./gradlew build generateReleaseJavadoc
 


### PR DESCRIPTION
It looks like something broke when CI images updated from Ubuntu 22.04 to 24.04 (along with other changes, presumably)