### PR TITLE
Upgrade OkHttp packages

### DIFF
--- a/divviup/build.gradle.kts
+++ b/divviup/build.gradle.kts
@@ -53,7 +53,8 @@ dependencies {
     implementation("com.squareup.okhttp3:okhttp:5.1.0")
     testImplementation(project(":divviup:commontest"))
     testImplementation("junit:junit:4.13.2")
-    testImplementation("com.squareup.okhttp3:mockwebserver:5.1.0")
+    testImplementation("com.squareup.okhttp3:mockwebserver3:5.1.0")
+    testImplementation("com.squareup.okhttp3:mockwebserver3-junit4:5.1.0")
     testImplementation("org.testcontainers:testcontainers:1.21.3")
     testImplementation("com.fasterxml.jackson.core:jackson-databind:2.19.1")
     testImplementation("ch.qos.logback:logback-core:1.5.18")
@@ -63,7 +64,8 @@ dependencies {
     androidTestImplementation(project(":divviup:commontest"))
     androidTestImplementation("androidx.test.ext:junit:1.2.1")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
-    androidTestImplementation("com.squareup.okhttp3:mockwebserver:5.1.0")
+    androidTestImplementation("com.squareup.okhttp3:mockwebserver3:5.1.0")
+    androidTestImplementation("com.squareup.okhttp3:mockwebserver3-junit4:5.1.0")
 }
 
 val rustTargets: List<String> by rootProject.extra

--- a/divviup/build.gradle.kts
+++ b/divviup/build.gradle.kts
@@ -50,10 +50,10 @@ android {
 }
 
 dependencies {
-    implementation("com.squareup.okhttp3:okhttp:4.12.0")
+    implementation("com.squareup.okhttp3:okhttp:5.1.0")
     testImplementation(project(":divviup:commontest"))
     testImplementation("junit:junit:4.13.2")
-    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
+    testImplementation("com.squareup.okhttp3:mockwebserver:5.1.0")
     testImplementation("org.testcontainers:testcontainers:1.21.3")
     testImplementation("com.fasterxml.jackson.core:jackson-databind:2.19.1")
     testImplementation("ch.qos.logback:logback-core:1.5.18")
@@ -63,7 +63,7 @@ dependencies {
     androidTestImplementation(project(":divviup:commontest"))
     androidTestImplementation("androidx.test.ext:junit:1.2.1")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
-    androidTestImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
+    androidTestImplementation("com.squareup.okhttp3:mockwebserver:5.1.0")
 }
 
 val rustTargets: List<String> by rootProject.extra

--- a/divviup/commontest/build.gradle.kts
+++ b/divviup/commontest/build.gradle.kts
@@ -29,5 +29,6 @@ android {
 }
 
 dependencies {
-    implementation("com.squareup.okhttp3:mockwebserver:5.1.0")
+    implementation("com.squareup.okhttp3:mockwebserver3:5.1.0")
+    implementation("com.squareup.okhttp3:mockwebserver3-junit4:5.1.0")
 }

--- a/divviup/commontest/build.gradle.kts
+++ b/divviup/commontest/build.gradle.kts
@@ -29,5 +29,5 @@ android {
 }
 
 dependencies {
-    implementation("com.squareup.okhttp3:mockwebserver:4.12.0")
+    implementation("com.squareup.okhttp3:mockwebserver:5.1.0")
 }

--- a/divviup/commontest/src/main/java/org/divviup/commontest/MockAggregator.java
+++ b/divviup/commontest/src/main/java/org/divviup/commontest/MockAggregator.java
@@ -4,8 +4,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Objects;
 
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
+import okhttp3.Headers;
 import okio.Buffer;
 
 public class MockAggregator {
@@ -23,16 +24,20 @@ public class MockAggregator {
         Buffer hpkeConfigListBuffer = loadHpkeConfigList();
         MockWebServer server = new MockWebServer();
         server.enqueue(
-                new MockResponse()
-                        .setHeader("Content-Type", "application/dap-hpke-config-list")
-                        .setBody(hpkeConfigListBuffer)
+                new MockResponse.Builder()
+                        .code(200)
+                        .addHeader("Content-Type", "application/dap-hpke-config-list")
+                        .body(hpkeConfigListBuffer)
+                        .build()
         );
         server.enqueue(
-                new MockResponse()
-                        .setHeader("Content-Type", "application/dap-hpke-config-list")
-                        .setBody(hpkeConfigListBuffer)
+                new MockResponse.Builder()
+                        .code(200)
+                        .addHeader("Content-Type", "application/dap-hpke-config-list")
+                        .body(hpkeConfigListBuffer)
+                        .build()
         );
-        server.enqueue(new MockResponse());
+        server.enqueue(new MockResponse(200, Headers.EMPTY, ""));
         server.start();
         return server;
     }

--- a/divviup/src/androidTest/java/org/divviup/android/InstrumentedSmokeTest.java
+++ b/divviup/src/androidTest/java/org/divviup/android/InstrumentedSmokeTest.java
@@ -71,19 +71,19 @@ public class InstrumentedSmokeTest {
 
     private static void basicUploadChecks(MockWebServer server) throws InterruptedException {
         RecordedRequest r1 = server.takeRequest();
-        assertEquals(r1.getMethod(), "GET");
-        assertEquals(r1.getUrl().encodedPath(), "/hpke_config");
-        assertEquals(r1.getUrl().encodedQuery(), "task_id=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+        assertEquals("GET", r1.getMethod());
+        assertEquals("/hpke_config", r1.getUrl().encodedPath());
+        assertEquals("task_id=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", r1.getUrl().encodedQuery());
 
         RecordedRequest r2 = server.takeRequest();
-        assertEquals(r2.getMethod(), "GET");
-        assertEquals(r2.getUrl().encodedPath(), "/hpke_config");
-        assertEquals(r2.getUrl().encodedQuery(), "task_id=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+        assertEquals("GET", r2.getMethod());
+        assertEquals("/hpke_config", r2.getUrl().encodedPath());
+        assertEquals("task_id=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", r2.getUrl().encodedQuery());
 
         RecordedRequest r3 = server.takeRequest();
-        assertEquals(r3.getMethod(), "PUT");
-        assertEquals(r3.getUrl().encodedPath(), "/tasks/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/reports");
-        assertEquals(r3.getHeaders().get("Content-Type"), "application/dap-report");
+        assertEquals("PUT", r3.getMethod());
+        assertEquals("/tasks/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/reports", r3.getUrl().encodedPath());
+        assertEquals("application/dap-report", r3.getHeaders().get("Content-Type"));
         assertTrue(r3.getBody().size() > 0);
     }
 }

--- a/divviup/src/androidTest/java/org/divviup/android/InstrumentedSmokeTest.java
+++ b/divviup/src/androidTest/java/org/divviup/android/InstrumentedSmokeTest.java
@@ -14,8 +14,8 @@ import android.content.Context;
 import java.io.IOException;
 import java.net.URI;
 
-import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.RecordedRequest;
+import mockwebserver3.MockWebServer;
+import mockwebserver3.RecordedRequest;
 
 @RunWith(AndroidJUnit4.class)
 public class InstrumentedSmokeTest {
@@ -72,16 +72,18 @@ public class InstrumentedSmokeTest {
     private static void basicUploadChecks(MockWebServer server) throws InterruptedException {
         RecordedRequest r1 = server.takeRequest();
         assertEquals(r1.getMethod(), "GET");
-        assertEquals(r1.getPath(), "/hpke_config?task_id=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+        assertEquals(r1.getUrl().encodedPath(), "/hpke_config");
+        assertEquals(r1.getUrl().encodedQuery(), "task_id=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
 
         RecordedRequest r2 = server.takeRequest();
         assertEquals(r2.getMethod(), "GET");
-        assertEquals(r2.getPath(), "/hpke_config?task_id=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+        assertEquals(r2.getUrl().encodedPath(), "/hpke_config");
+        assertEquals(r2.getUrl().encodedQuery(), "task_id=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
 
         RecordedRequest r3 = server.takeRequest();
         assertEquals(r3.getMethod(), "PUT");
-        assertEquals(r3.getPath(), "/tasks/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/reports");
-        assertEquals(r3.getHeader("Content-Type"), "application/dap-report");
+        assertEquals(r3.getUrl().encodedPath(), "/tasks/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/reports");
+        assertEquals(r3.getHeaders().get("Content-Type"), "application/dap-report");
         assertTrue(r3.getBody().size() > 0);
     }
 }

--- a/divviup/src/test/java/org/divviup/android/HostSmokeTest.java
+++ b/divviup/src/test/java/org/divviup/android/HostSmokeTest.java
@@ -81,19 +81,19 @@ public class HostSmokeTest {
 
     private static void basicUploadChecks(MockWebServer server) throws InterruptedException {
         RecordedRequest r1 = server.takeRequest();
-        assertEquals(r1.getMethod(), "GET");
-        assertEquals(r1.getUrl().encodedPath(), "/hpke_config");
-        assertEquals(r1.getUrl().encodedQuery(), "task_id=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+        assertEquals("GET", r1.getMethod());
+        assertEquals("/hpke_config", r1.getUrl().encodedPath());
+        assertEquals("task_id=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", r1.getUrl().encodedQuery());
 
         RecordedRequest r2 = server.takeRequest();
-        assertEquals(r2.getMethod(), "GET");
-        assertEquals(r2.getUrl().encodedPath(), "/hpke_config");
-        assertEquals(r2.getUrl().encodedQuery(), "task_id=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+        assertEquals("GET", r2.getMethod());
+        assertEquals("/hpke_config", r2.getUrl().encodedPath());
+        assertEquals("task_id=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", r2.getUrl().encodedQuery());
 
         RecordedRequest r3 = server.takeRequest();
-        assertEquals(r3.getMethod(), "PUT");
-        assertEquals(r3.getUrl().encodedPath(), "/tasks/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/reports");
-        assertEquals(r3.getHeaders().get("Content-Type"), "application/dap-report");
+        assertEquals("PUT", r3.getMethod());
+        assertEquals("/tasks/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/reports", r3.getUrl().encodedPath());
+        assertEquals("application/dap-report", r3.getHeaders().get("Content-Type"));
         assertTrue(r3.getBody().size() > 0);
     }
 }

--- a/divviup/src/test/java/org/divviup/android/HostSmokeTest.java
+++ b/divviup/src/test/java/org/divviup/android/HostSmokeTest.java
@@ -17,8 +17,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 import java.io.IOException;
 import java.net.URI;
 
-import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.RecordedRequest;
+import mockwebserver3.MockWebServer;
+import mockwebserver3.RecordedRequest;
 
 @RunWith(MockitoJUnitRunner.class)
 public class HostSmokeTest {
@@ -82,16 +82,18 @@ public class HostSmokeTest {
     private static void basicUploadChecks(MockWebServer server) throws InterruptedException {
         RecordedRequest r1 = server.takeRequest();
         assertEquals(r1.getMethod(), "GET");
-        assertEquals(r1.getPath(), "/hpke_config?task_id=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+        assertEquals(r1.getUrl().encodedPath(), "/hpke_config");
+        assertEquals(r1.getUrl().encodedQuery(), "task_id=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
 
         RecordedRequest r2 = server.takeRequest();
         assertEquals(r2.getMethod(), "GET");
-        assertEquals(r2.getPath(), "/hpke_config?task_id=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+        assertEquals(r2.getUrl().encodedPath(), "/hpke_config");
+        assertEquals(r2.getUrl().encodedQuery(), "task_id=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
 
         RecordedRequest r3 = server.takeRequest();
         assertEquals(r3.getMethod(), "PUT");
-        assertEquals(r3.getPath(), "/tasks/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/reports");
-        assertEquals(r3.getHeader("Content-Type"), "application/dap-report");
+        assertEquals(r3.getUrl().encodedPath(), "/tasks/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/reports");
+        assertEquals(r3.getHeaders().get("Content-Type"), "application/dap-report");
         assertTrue(r3.getBody().size() > 0);
     }
 }


### PR DESCRIPTION
This upgrades OkHttp dependencies, and switches to the new `mockwebserver3` package. Supersedes #362 and #363.