### PR TITLE
Include OS version in cache key

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,9 @@ jobs:
       CARGO_TERM_COLOR: always
       RUSTFLAGS: "-D warnings"
     steps:
+    - name: Get OS version
+      id: os-version
+      run: echo "release=$(lsb_release --release --short)" >> $GITHUB_OUTPUT
     - name: Checkout
       uses: actions/checkout@v5
     - name: Setup Java
@@ -50,7 +53,7 @@ jobs:
     - name: Rust caching
       uses: Swatinem/rust-cache@v2
       with:
-        key: ${{ steps.rust-toolchain.outputs.cachekey }}
+        key: "${{ steps.os-version.outputs.release }}-${{ steps.rust-toolchain.outputs.cachekey }}"
         workspaces: divviup/rust
     - name: Rust format
       working-directory: divviup/rust


### PR DESCRIPTION
Recent Dependabot PRs for Rust dependencies have been failing during aws-lc-sys compilation, with strange errors from CMake. I tried deleting all build cache entries and retrying a job, and this fixed it. I think we are probably running into build cache reuse issues across OS versions again, since the `ubuntu-latest` GitHub Actions image switched to a new version. This PR fixes that going forward by including the OS version in the Rust cache key.